### PR TITLE
overview page renders with the stats from the app selected

### DIFF
--- a/src/components/dashboard/App.jsx
+++ b/src/components/dashboard/App.jsx
@@ -1,10 +1,5 @@
 import React from 'react';
 
-import Overview from './my-apps-subviews/Overview.jsx';
-import Keys from './my-apps-subviews/Keys.jsx';
-import Data from './my-apps-subviews/Data.jsx';
-import Plan from './my-apps-subviews/Plan.jsx';
-
 import '../../../node_modules/font-awesome/css/font-awesome.css';
 import '../../styles/dashboard/App.scss';
 
@@ -35,26 +30,6 @@ class MyApps extends React.Component {
                 </div>
             </div>
         );
-
-
-        // switch (subView) {
-        //     case 'overview':
-        //         return (
-        //             <Overview selectedApp={selectedApp} />
-        //         );
-        //     case 'keys':
-        //         return (
-        //             <Keys selectedApp={selectedApp} />
-        //         );
-        //     case 'data':
-        //         return (
-        //             <Data selectedApp={selectedApp} />
-        //         );
-        //     case 'plan':
-        //         return (
-        //             <Plan selectedApp={selectedApp} />
-        //         );
-        // }
 
     }
 }

--- a/src/components/dashboard/DashboardPage.jsx
+++ b/src/components/dashboard/DashboardPage.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 import { FormGroup, ControlLabel, FormControl, Button } from 'react-bootstrap';
 import VirtualizedSelect from 'react-virtualized-select';
 
+import Overview from './my-apps-subviews/Overview.jsx';
+import Keys from './my-apps-subviews/Keys.jsx';
+import Data from './my-apps-subviews/Data.jsx';
+import Plan from './my-apps-subviews/Plan.jsx';
 import Login from './Login.jsx';
 import App from './App.jsx';
 import MyAccount from './MyAccount.jsx';
@@ -21,6 +25,7 @@ class DashboardPage extends React.Component {
 
         this.state = {
             view: {label: 'my-apps', value: 'my-apps'},
+            subView: 'overview',
             selectedApp: null,
             deleteApp: null,
             show: false,
@@ -211,12 +216,64 @@ class DashboardPage extends React.Component {
         });
     }
 
+    get subview() {
+
+        switch (this.state.subView) {
+            case 'overview':
+                return (
+                    <Overview selectedApp={this.state.selectedApp} />
+                );
+            case 'keys':
+                return (
+                    <Keys selectedApp={this.state.selectedApp} />
+                );
+            case 'data':
+                return (
+                    <Data selectedApp={this.state.selectedApp} />
+                );
+            case 'plan':
+                return (
+                    <Plan selectedApp={this.state.selectedApp} />
+                );
+        }
+    }
+
+    get subViewBtn() {
+        const subViewButtons = ['overview', 'keys', 'data', 'plan'];
+
+        return subViewButtons.map((btn) => {
+            return(
+                <div className="subview-buttons">
+                    <button
+                        name={btn}
+                        className={`btn ${this.state.subView == btn ? 'active' : null}`}
+                        onClick={() => this.setState({ subView : btn })}
+                    >   
+                        { btn }
+                        <div className={`underline ${this.state.subView == btn ? 'active' : null}`}></div>
+                    </button>
+                </div>
+            );
+        })
+
+    }
+
     get selectedApp() {
+
         return(
             <div>
-                <h1>Selected App</h1>
+                
+                <div className="row">
+                    <div className="subview-button-layout">
+                        { this.subViewBtn }
+                    </div>
+                </div>
+
+                <div className="row">
+                    { this.subview }
+                </div>
             </div>
-        )
+        );
     }
 
     get content() {
@@ -224,23 +281,21 @@ class DashboardPage extends React.Component {
         switch(this.state.view.label) {
             case 'my-apps':
                 return (
-                    <div className="container-fluid">
-                        <div className="my-apps">
-                            <div className="row">
-                            <div className="col-md-3 pull-right">
-                                <div style={{marginBottom: '50px', textAlign: 'right'}}>
-                                    <button 
-                                        className="btn btn-default"
-                                        onClick={() => this.onShowModal('create app', null)}
-                                    >
-                                        Create App
-                                    </button>
-                                </div>
+                    <div className="my-apps">
+                        <div className="row">
+                        <div className="col-md-3 pull-right">
+                            <div style={{marginBottom: '50px', textAlign: 'right'}}>
+                                <button 
+                                    className="btn btn-default"
+                                    onClick={() => this.onShowModal('create app', null)}
+                                >
+                                    Create App
+                                </button>
                             </div>
-                            </div>
-                            <div className="row">
-                                { !this.state.selectedApp ? this.userApps : this.selectedApp }
-                            </div>
+                        </div>
+                        </div>
+                        <div className="row">
+                            { !this.state.selectedApp ? this.userApps : this.selectedApp }
                         </div>
                     </div>
                 );
@@ -265,9 +320,11 @@ class DashboardPage extends React.Component {
                 <div className="row">
                     <a className="pull-right" style={{marginRight: '20px'}} onClick={() => firebase.auth().signOut()}>Sign-out</a>
                 </div>
-                {this.breadcrumbs}
-                {this.content}
-                { this.showModal }
+                <div className="container-fluid">
+                    {this.breadcrumbs}
+                    {this.content}
+                    { this.showModal }
+                </div>
                </div>
             </div>
         );

--- a/src/components/dashboard/my-apps-subviews/Overview.jsx
+++ b/src/components/dashboard/my-apps-subviews/Overview.jsx
@@ -1,10 +1,25 @@
 import React from 'react';
 
-const Overview = () => (
-    <div>
+const Overview = (props) => (
+    <div className="row">
 
-        <h1>Overview</h1>
-
+        <div className="overview-panel" style={{margin: '60px auto', width: '95%'}}>
+            {(() => {
+                return props.selectedApp.stats.map((stat) => {
+                    return(
+                        <div className="col-md-4">
+                            <div className="panel panel-default">
+                                <div className="panel-body" style={{textAlign: 'center'}}>
+                                        <p style={{fontSize: '30px', textTransform: 'uppercase'}}> { stat.type }</p>
+                                        <p> { stat.key }</p>
+                                </div>
+                            </div>
+                    </div>
+                    );
+                })
+            })()}
+        </div>
+        
     </div>
 );
 

--- a/src/data/apps.js
+++ b/src/data/apps.js
@@ -3,15 +3,15 @@ const data = [
         name: "my-app-1",
         stats: [
             {
-                type: "a",
+                type: "stat a",
                 key: "xxxxxxxx"
             },
             {
-                type: "b",
+                type: "stat b",
                 key: "xxxxxxxx"
             },
             {
-                type: "c",
+                type: "stat c",
                 key: "xxxxxxxx"
             }
         ]
@@ -20,15 +20,15 @@ const data = [
         name: "my-app-2",
         stats: [
             {
-                type: "a",
+                type: "stat a",
                 key: "xxxxxxxx"
             },
             {
-                type: "b",
+                type: "stat b",
                 key: "xxxxxxxx"
             },
             {
-                type: "c",
+                type: "stat c",
                 key: "xxxxxxxx"
             }
         ]
@@ -37,15 +37,15 @@ const data = [
         name: "my-app-3",
         stats: [
             {
-                type: "a",
+                type: "stat a",
                 key: "xxxxxxxx"
             },
             {
-                type: "b",
+                type: "stat b",
                 key: "xxxxxxxx"
             },
             {
-                type: "c",
+                type: "stat c",
                 key: "xxxxxxxx"
             }
         ]
@@ -54,15 +54,15 @@ const data = [
         name: "my-app-4",
         stats: [
             {
-                type: "a",
+                type: "stat a",
                 key: "xxxxxxxx"
             },
             {
-                type: "b",
+                type: "stat b",
                 key: "xxxxxxxx"
             },
             {
-                type: "c",
+                type: "stat c",
                 key: "xxxxxxxx"
             }
         ]

--- a/src/styles/dashboard/DashboardPage.scss
+++ b/src/styles/dashboard/DashboardPage.scss
@@ -21,5 +21,36 @@
             }
         }
     }
+
+    .subview-button-layout {
+        margin: 0 auto;
+        width: 400px;
+
+        .subview-buttons {
+            display: inline;
+            margin-left: 20px;
+            
+            button {
+                background: none;
+                font-size: 20px;
+
+                &.active {
+                    box-shadow: none; 
+                    color: lightgrey;
+                }
+
+                &:focus {
+                    outline: none;
+                    box-shadow: none;
+                }
+            }
+
+            .underline {
+                &.active {
+                    border-top: 1px solid black;
+                }
+            }
+        }
+    }
    
 }


### PR DESCRIPTION
This branch should show the updated breadcrumb with the button to go back to my app layout view. Also when you are at that view you can click on an app and drill down to the single app section where you see the sub nav to jump from overview section to keys, data and plan view. The overview section is shown as the default view, and it has a light grey selected state, with a black underline showing what view the user is currently on. 

Also you can see the stats for that app.