### PR TITLE
 fixed issues for price pages

### DIFF
--- a/src/components/pricing/PricingPage.jsx
+++ b/src/components/pricing/PricingPage.jsx
@@ -10,7 +10,7 @@ class PricingPage extends Component {
         super(props);
 
         this.state = {
-            activeKey: '',
+            collapsiblePanel: [true , true, true, true, true],
             prices: [
                 {
                     icon: 'icon-free',
@@ -89,15 +89,6 @@ class PricingPage extends Component {
                 }
             ]
         }; 
-
-        this.onHandleSelect = this.onHandleSelect.bind(this);
-
-    }
-
-
-    onHandleSelect(activeKey) {
-
-        this.setState({ activeKey });
     }
 
     get plans() {
@@ -128,12 +119,32 @@ class PricingPage extends Component {
     }
 
     get accordionPanels() {
-        return this.state.faqs.map((faq) => {
+
+        let expand = 'true';
+        
+        return this.state.faqs.map((faq, index) => {
             return(
                 <div className="col-md-12">
-                    <Panel key={faq.key} eventKey={faq.key} style={{ border: 'none' }}>
+                    <Panel 
+                        key={faq.key} 
+                        id={`collapsible-panel-${faq.key}`} 
+                        defaultExpanded 
+                        style={{ border: 'none' }}
+                        onToggle={() => {
+                            console.log('something changed');
+                            const panels = this.state.collapsiblePanel; 
+                            panels[index] = !this.state.collapsiblePanel[index];
+                            this.setState({
+                                collapsiblePanel: panels
+                            })
+
+                            console.log('state', this.state.collapsiblePanel);
+                            
+                            
+                        }}
+                    >
                         <Panel.Heading>
-                            <Panel.Title toggle> <span className="toggle-icon"> {this.state.activeKey === faq.key ? '-' : '+'}</span> {faq.heading}</Panel.Title>
+                            <Panel.Title toggle> <span className="toggle-icon"> {this.state.collapsiblePanel[index] ? '-' : '+'}</span> {faq.heading}</Panel.Title>
                         </Panel.Heading>
                         <Panel.Body collapsible style={{ paddingLeft: '30px', borderTop: 'none' }}>
                             {(() => {
@@ -213,19 +224,10 @@ class PricingPage extends Component {
                             </div>
                         </div>
 
-                        <div className="col-md-12">
-                           <PanelGroup
-                                accordion
-                                id="faq-accordion"
-                                activeKey={this.state.activeKey}
-                                onSelect={this.onHandleSelect}
-                           >
-
-                            <div className="row">
-                                    {this.accordionPanels}
+                        <div className="row" >
+                            <div id="faq-accordion">
+                                {this.accordionPanels}
                             </div>
-
-                           </PanelGroup>
                         </div>
 
                     </div>

--- a/src/styles/home/sections/FullFeatureSet.scss
+++ b/src/styles/home/sections/FullFeatureSet.scss
@@ -13,8 +13,12 @@
     font-size: 30px;
   }
     a {
-      text-decoration: underline;
       color: $action-purple;
+      border-bottom: 1px solid $action-purple;
+
+      &:hover, &:focus{
+        text-decoration: none;
+      }
     }
     h4 {
       font-weight: 300;

--- a/src/styles/pricing/PricingPage.scss
+++ b/src/styles/pricing/PricingPage.scss
@@ -28,6 +28,7 @@
             .panel-heading {
 
                 text-transform: capitalize;
+                text-align: center;
                 border-color: white; 
                 background-color: white;
 
@@ -71,10 +72,14 @@
             padding-top: 100px;
 
             span {
-                text-decoration: underline;
 
                 a {
-                    color: #ec0064;; 
+                    color: #ec0064;
+                    border-bottom : 1px solid #ec0064;
+
+                    &:hover, &:focus {
+                        text-decoration: none;
+                    }
                 }
             }
         }
@@ -95,9 +100,9 @@
     }
 
     #faq-accordion {
+        width: 60%;
         margin: 0 auto;
         margin-bottom: 100px;
-        width: 60%;
 
         .panel-default {
 
@@ -106,6 +111,7 @@
 
             .panel-heading {
                 background-color: transparent;
+                border-bottom: none;
 
                 .panel-title{
                     font-size: 13px;


### PR DESCRIPTION
- accordion are all expanded by default 
- when closing them you can close one at a time, and it changes from - to + 
- center title and icon for price plans 
- the style for the here text to have more space between the underline 